### PR TITLE
Further UI7 compatibility modifications: added set temperature setpoint on house mode change in dashboard 

### DIFF
--- a/D_SmartVT1.xml
+++ b/D_SmartVT1.xml
@@ -45,6 +45,11 @@
       </service>
       <service>
         <serviceType>urn:schemas-upnp-org:service:TemperatureSetpoint:1</serviceType>
+        <serviceId>urn:upnp-org:serviceId:TemperatureSetpoint1</serviceId>
+        <SCPDURL>S_TemperatureSetpoint1.xml</SCPDURL>
+      </service>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:TemperatureSetpoint:1</serviceType>
         <serviceId>urn:upnp-org:serviceId:TemperatureSetpoint1_Heat</serviceId>
         <SCPDURL>S_TemperatureSetpoint1.xml</SCPDURL>
       </service>

--- a/I_SmartVT1.xml
+++ b/I_SmartVT1.xml
@@ -500,6 +500,21 @@
 			</job>
 		</action>
 		<action>
+			<serviceId>urn:upnp-org:serviceId:TemperatureSetpoint1</serviceId>
+			<name>SetCurrentSetpoint</name>
+			<job>
+			-- On conditionne le lancement des fonctions au mode selectionne pour ne pas recalculer le coef quand on est dans lautre mode
+				luup.variable_set (TSH_SID, "CurrentSetpoint", lul_settings.NewCurrentSetpoint, lul_device)
+				luup.variable_set (TSC_SID, "CurrentSetpoint", lul_settings.NewCurrentSetpoint, lul_device)
+				local EnergyModeStatus = luup.variable_get (HVUOM_SID, "EnergyModeStatus", lul_device)
+                local ModeStatus = luup.variable_get (HVUOM_SID, "ModeStatus", lul_device)
+				if ((ModeStatus == "AutoChangeOver") and (EnergyModeStatus == "Normal")) then
+                    AutoChangeOver(lul_device)
+                end
+				return 4, 5
+			</job>
+		</action>
+		<action>
 			<serviceId>urn:upnp-org:serviceId:TemperatureSetpoint1_Cool</serviceId>
 			<name>SetCurrentSetpoint</name>
 			<job>


### PR DESCRIPTION
Added management of automatic change of temperature set point when house mode is changed in UI7 dashboard. 
In current (master) revision temperature set-point was not updated when house mode is changed. 

When house mode was changed we can see following error in the log:
"..JobHandler_LuaUPnP::HandleActionRequest can't find urn:upnp-org:serviceId:TemperatureSetpoint1 <0x2b3ce680>.."

It was caused that current version of plug-in is not fully compatible with new UI7 :
"..NOTE: On UI7, urn:upnp-org:serviceId:TemperatureSetpoint1_Heat and urn:upnp-org:serviceId:TemperatureSetpoint1_Cool are obsolete..."
http://wiki.micasaverde.com/index.php/Luup_UPnP_Variables_and_Actions

It is the reason why "urn:upnp-org:serviceId:TemperatureSetpoint1" service have to be created.

In the modified code by me: when set point is changed, both heat and cool setpoints are set to selected (same) value. I have performed some testing. Till now I haven't found any problems caused by the modification.

Please let me know if you have any questions/comments.
D
